### PR TITLE
Don't scan for unused params in DDP (main_swav.py)

### DIFF
--- a/main_swav.py
+++ b/main_swav.py
@@ -190,8 +190,7 @@ def main():
     # wrap model
     model = nn.parallel.DistributedDataParallel(
         model,
-        device_ids=[args.gpu_to_work_on],
-        find_unused_parameters=True,
+        device_ids=[args.gpu_to_work_on]
     )
 
     # optionally resume from a checkpoint


### PR DESCRIPTION
Addresses warning described in #63 regarding a lack of unused parameters in the distributed model despite searching for them. I haven't benchmarked to see whether there are any tangible gains here, but at the very least it shouldn't hurt :)